### PR TITLE
Put timestamp in front of every attachment filename

### DIFF
--- a/cmd_export_attachments.go
+++ b/cmd_export_attachments.go
@@ -305,13 +305,13 @@ func conversationDir(d at.Dir, conv *signal.Conversation) (at.Dir, error) {
 func attachmentFilename(d at.Dir, att *signal.Attachment) (string, error) {
 	var name string
 	if att.FileName != "" {
-		name = sanitiseFilename(att.FileName)
+		name = time.UnixMilli(att.TimeSent).Format("2006-01-02-15-04-05") + "-" + sanitiseFilename(att.FileName)
 	} else {
 		ext, err := extensionFromContentType(att.ContentType)
 		if err != nil {
 			return "", err
 		}
-		name = "attachment-" + time.UnixMilli(att.TimeSent).Format("2006-01-02-15-04-05") + ext
+		name = time.UnixMilli(att.TimeSent).Format("2006-01-02-15-04-05") + "-attachment" + ext
 	}
 
 	return uniqueFilename(d, name)


### PR DESCRIPTION
Dear @tbvdm,
I recently used sigtop to export image attachments from Signal. I was wondering if it wouldn't be better to add the timestamp for attachments in front of the filenames rather than at the end "attachment-YYYY-MM-DD...".

Obviously this could be a command line option. What do you think?