### PR TITLE
Signal Beta support

### DIFF
--- a/cmd_check_database.go
+++ b/cmd_check_database.go
@@ -26,15 +26,18 @@ import (
 var cmdCheckDatabaseEntry = cmdEntry{
 	name:  "check-database",
 	alias: "check",
-	usage: "[-d signal-directory] [-k [system:]keyfile]",
+	usage: "[-B] [-d signal-directory] [-k [system:]keyfile]",
 	exec:  cmdCheckDatabase,
 }
 
 func cmdCheckDatabase(args []string) cmdStatus {
-	getopt.ParseArgs("d:k:p:", args)
+	getopt.ParseArgs("Bd:k:p:", args)
 	var dArg, kArg getopt.Arg
+	Bflag := false
 	for getopt.Next() {
 		switch opt := getopt.Option(); opt {
+		case 'B':
+			Bflag = true
 		case 'd':
 			dArg = getopt.OptionArg()
 		case 'p':
@@ -63,7 +66,7 @@ func cmdCheckDatabase(args []string) cmdStatus {
 		signalDir = dArg.String()
 	} else {
 		var err error
-		signalDir, err = signal.DesktopDir()
+		signalDir, err = signal.DesktopDir(Bflag)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -84,9 +87,9 @@ func cmdCheckDatabase(args []string) cmdStatus {
 
 	var ctx *signal.Context
 	if key == nil {
-		ctx, err = signal.Open(signalDir)
+		ctx, err = signal.Open(Bflag, signalDir)
 	} else {
-		ctx, err = signal.OpenWithEncryptionKey(signalDir, key)
+		ctx, err = signal.OpenWithEncryptionKey(Bflag, signalDir, key)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/cmd_export_attachments.go
+++ b/cmd_export_attachments.go
@@ -51,7 +51,7 @@ type attMode struct {
 var cmdExportAttachmentsEntry = cmdEntry{
 	name:  "export-attachments",
 	alias: "att",
-	usage: "[-iMm] [-c conversation] [-d signal-directory] [-k [system:]keyfile] [-s interval] [directory]",
+	usage: "[-BiMm] [-c conversation] [-d signal-directory] [-k [system:]keyfile] [-s interval] [directory]",
 	exec:  cmdExportAttachments,
 }
 
@@ -61,11 +61,14 @@ func cmdExportAttachments(args []string) cmdStatus {
 		incremental: false,
 	}
 
-	getopt.ParseArgs("c:d:ik:Mmp:s:", args)
+	getopt.ParseArgs("Bc:d:ik:Mmp:s:", args)
 	var dArg, kArg, sArg getopt.Arg
 	var selectors []string
+	Bflag := false
 	for getopt.Next() {
 		switch getopt.Option() {
+		case 'B':
+			Bflag = true
 		case 'c':
 			selectors = append(selectors, getopt.OptionArg().String())
 		case 'd':
@@ -114,7 +117,7 @@ func cmdExportAttachments(args []string) cmdStatus {
 		signalDir = dArg.String()
 	} else {
 		var err error
-		signalDir, err = signal.DesktopDir()
+		signalDir, err = signal.DesktopDir(Bflag)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -162,9 +165,9 @@ func cmdExportAttachments(args []string) cmdStatus {
 
 	var ctx *signal.Context
 	if key == nil {
-		ctx, err = signal.Open(signalDir)
+		ctx, err = signal.Open(Bflag, signalDir)
 	} else {
-		ctx, err = signal.OpenWithEncryptionKey(signalDir, key)
+		ctx, err = signal.OpenWithEncryptionKey(Bflag, signalDir, key)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/cmd_export_avatars.go
+++ b/cmd_export_avatars.go
@@ -30,16 +30,19 @@ import (
 var cmdExportAvatarsEntry = cmdEntry{
 	name:  "export-avatars",
 	alias: "avt",
-	usage: "[-c conversation] [-d signal-directory] [-k [system:]keyfile] [directory]",
+	usage: "[-B] [-c conversation] [-d signal-directory] [-k [system:]keyfile] [directory]",
 	exec:  cmdExportAvatars,
 }
 
 func cmdExportAvatars(args []string) cmdStatus {
-	getopt.ParseArgs("c:d:k:p:", args)
+	getopt.ParseArgs("Bc:d:k:p:", args)
 	var dArg, kArg getopt.Arg
 	var selectors []string
+	Bflag := false
 	for getopt.Next() {
 		switch getopt.Option() {
+		case 'B':
+			Bflag = true
 		case 'c':
 			selectors = append(selectors, getopt.OptionArg().String())
 		case 'd':
@@ -80,7 +83,7 @@ func cmdExportAvatars(args []string) cmdStatus {
 		signalDir = dArg.String()
 	} else {
 		var err error
-		signalDir, err = signal.DesktopDir()
+		signalDir, err = signal.DesktopDir(Bflag)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -105,9 +108,9 @@ func cmdExportAvatars(args []string) cmdStatus {
 
 	var ctx *signal.Context
 	if key == nil {
-		ctx, err = signal.Open(signalDir)
+		ctx, err = signal.Open(Bflag, signalDir)
 	} else {
-		ctx, err = signal.OpenWithEncryptionKey(signalDir, key)
+		ctx, err = signal.OpenWithEncryptionKey(Bflag, signalDir, key)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/cmd_export_database.go
+++ b/cmd_export_database.go
@@ -27,15 +27,18 @@ import (
 var cmdExportDatabaseEntry = cmdEntry{
 	name:  "export-database",
 	alias: "db",
-	usage: "[-d signal-directory] [-k [system:]keyfile] file",
+	usage: "[-B] [-d signal-directory] [-k [system:]keyfile] file",
 	exec:  cmdExportDatabase,
 }
 
 func cmdExportDatabase(args []string) cmdStatus {
-	getopt.ParseArgs("d:k:p:", args)
+	getopt.ParseArgs("Bd:k:p:", args)
 	var dArg, kArg getopt.Arg
+	Bflag := false
 	for getopt.Next() {
 		switch getopt.Option() {
+		case 'B':
+			Bflag = true
 		case 'd':
 			dArg = getopt.OptionArg()
 		case 'p':
@@ -67,7 +70,7 @@ func cmdExportDatabase(args []string) cmdStatus {
 		signalDir = dArg.String()
 	} else {
 		var err error
-		signalDir, err = signal.DesktopDir()
+		signalDir, err = signal.DesktopDir(Bflag)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -101,9 +104,9 @@ func cmdExportDatabase(args []string) cmdStatus {
 
 	var ctx *signal.Context
 	if key == nil {
-		ctx, err = signal.Open(signalDir)
+		ctx, err = signal.Open(Bflag, signalDir)
 	} else {
-		ctx, err = signal.OpenWithEncryptionKey(signalDir, key)
+		ctx, err = signal.OpenWithEncryptionKey(Bflag, signalDir, key)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/cmd_export_key.go
+++ b/cmd_export_key.go
@@ -27,16 +27,19 @@ import (
 var cmdExportKeyEntry = cmdEntry{
 	name:  "export-key",
 	alias: "key",
-	usage: "[-D] [-d signal-directory] [-k [system:]keyfile] [file]",
+	usage: "[-BD] [-d signal-directory] [-k [system:]keyfile] [file]",
 	exec:  cmdExportKey,
 }
 
 func cmdExportKey(args []string) cmdStatus {
-	getopt.ParseArgs("Dd:k:", args)
+	getopt.ParseArgs("BDd:k:", args)
 	var dArg, kArg getopt.Arg
 	exportDBKey := false
+	Bflag := false
 	for getopt.Next() {
 		switch opt := getopt.Option(); opt {
+		case 'B':
+			Bflag = true
 		case 'D':
 			exportDBKey = true
 		case 'd':
@@ -74,7 +77,7 @@ func cmdExportKey(args []string) cmdStatus {
 		signalDir = dArg.String()
 	} else {
 		var err error
-		signalDir, err = signal.DesktopDir()
+		signalDir, err = signal.DesktopDir(Bflag)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -95,9 +98,9 @@ func cmdExportKey(args []string) cmdStatus {
 
 	var ctx *signal.Context
 	if key == nil {
-		ctx, err = signal.Open(signalDir)
+		ctx, err = signal.Open(Bflag, signalDir)
 	} else {
-		ctx, err = signal.OpenWithEncryptionKey(signalDir, key)
+		ctx, err = signal.OpenWithEncryptionKey(Bflag, signalDir, key)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/cmd_export_messages.go
+++ b/cmd_export_messages.go
@@ -43,7 +43,7 @@ type msgMode struct {
 var cmdExportMessagesEntry = cmdEntry{
 	name:  "export-messages",
 	alias: "msg",
-	usage: "[-i] [-c conversation] [-d signal-directory] [-f format] [-k [system:]keyfile] [-s interval] [directory]",
+	usage: "[-Bi] [-c conversation] [-d signal-directory] [-f format] [-k [system:]keyfile] [-s interval] [directory]",
 	exec:  cmdExportMessages,
 }
 
@@ -53,11 +53,14 @@ func cmdExportMessages(args []string) cmdStatus {
 		incremental: false,
 	}
 
-	getopt.ParseArgs("c:d:f:ik:p:s:", args)
+	getopt.ParseArgs("Bc:d:f:ik:p:s:", args)
 	var dArg, kArg, sArg getopt.Arg
 	var selectors []string
+	Bflag := false
 	for getopt.Next() {
 		switch getopt.Option() {
+		case 'B':
+			Bflag = true
 		case 'c':
 			selectors = append(selectors, getopt.OptionArg().String())
 		case 'd':
@@ -113,7 +116,7 @@ func cmdExportMessages(args []string) cmdStatus {
 		signalDir = dArg.String()
 	} else {
 		var err error
-		signalDir, err = signal.DesktopDir()
+		signalDir, err = signal.DesktopDir(Bflag)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -147,9 +150,9 @@ func cmdExportMessages(args []string) cmdStatus {
 
 	var ctx *signal.Context
 	if key == nil {
-		ctx, err = signal.Open(signalDir)
+		ctx, err = signal.Open(Bflag, signalDir)
 	} else {
-		ctx, err = signal.OpenWithEncryptionKey(signalDir, key)
+		ctx, err = signal.OpenWithEncryptionKey(Bflag, signalDir, key)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/cmd_query_database.go
+++ b/cmd_query_database.go
@@ -28,15 +28,18 @@ import (
 var cmdQueryDatabaseEntry = cmdEntry{
 	name:  "query-database",
 	alias: "query",
-	usage: "[-d signal-directory] [-k [system:]keyfile] [-o outfile] query",
+	usage: "[-B] [-d signal-directory] [-k [system:]keyfile] [-o outfile] query",
 	exec:  cmdQueryDatabase,
 }
 
 func cmdQueryDatabase(args []string) cmdStatus {
-	getopt.ParseArgs("d:k:p:o:", args)
+	getopt.ParseArgs("Bd:k:p:o:", args)
 	var dArg, kArg, oArg getopt.Arg
+	Bflag := false
 	for getopt.Next() {
 		switch opt := getopt.Option(); opt {
+		case 'B':
+			Bflag = true
 		case 'd':
 			dArg = getopt.OptionArg()
 		case 'p':
@@ -77,7 +80,7 @@ func cmdQueryDatabase(args []string) cmdStatus {
 		signalDir = dArg.String()
 	} else {
 		var err error
-		signalDir, err = signal.DesktopDir()
+		signalDir, err = signal.DesktopDir(Bflag)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -98,9 +101,9 @@ func cmdQueryDatabase(args []string) cmdStatus {
 
 	var ctx *signal.Context
 	if key == nil {
-		ctx, err = signal.Open(signalDir)
+		ctx, err = signal.Open(Bflag, signalDir)
 	} else {
-		ctx, err = signal.OpenWithEncryptionKey(signalDir, key)
+		ctx, err = signal.OpenWithEncryptionKey(Bflag, signalDir, key)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/signal/const.go
+++ b/signal/const.go
@@ -21,6 +21,9 @@ const (
 	ConfigFile    = "config.json"
 	AttachmentDir = "attachments.noindex"
 
+	AppName       = "Signal"
+	AppNameBeta   = "Signal Beta"
+
 	// Content type of the long-text attachment of a long message
 	LongTextType = "text/x-signal-plain"
 

--- a/signal/dir.go
+++ b/signal/dir.go
@@ -21,14 +21,18 @@ import (
 	"path/filepath"
 )
 
-func DesktopDir() (string, error) {
+func DesktopDir(betaApp bool) (string, error) {
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		return "", err
 	}
+	appName := AppName
+	if betaApp {
+		appName = AppNameBeta
+	}
 
 	// Try the default directory
-	defDir := filepath.Join(configDir, "Signal")
+	defDir := filepath.Join(configDir, appName)
 	if ok, err := tryDesktopDir(defDir); ok {
 		return defDir, err
 	}

--- a/sigtop.1
+++ b/sigtop.1
@@ -12,7 +12,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd December 6, 2024
+.Dd December 19, 2024
 .Dt SIGTOP 1
 .Os
 .Sh NAME
@@ -60,10 +60,26 @@ the
 .Fl d
 option (see below).
 .Pp
+To use
+.Nm
+with Signal Desktop Beta, use the
+.Fl B
+option (see below).
+With this option,
+.Nm
+uses the encryption key and default directory locations for Signal Desktop
+Beta.
+The directory location can still be overridden with
+.Fl d .
+.Pp
 The commands are as follows:
 .Bl -tag -width Ds
 .Tg check
-.It Ic check-database Op Fl d Ar signal-directory
+.It Xo
+.Ic check-database
+.Op Fl B
+.Op Fl d Ar signal-directory
+.Xc
 .D1 Pq Alias: Ic check
 .Pp
 Check the integrity of the encrypted Signal Desktop database.
@@ -76,7 +92,7 @@ pragmas.
 .Tg att
 .It Xo
 .Ic export-attachments
-.Op Fl iMm
+.Op Fl BiMm
 .Op Fl c Ar conversation
 .Op Fl d Ar signal-directory
 .Op Fl s Ar interval
@@ -133,6 +149,7 @@ section below for details.
 .Tg avt
 .It Xo
 .Ic export-avatars
+.Op Fl B
 .Op Fl c Ar conversation
 .Op Fl d Ar signal-directory
 .Op Ar directory
@@ -156,7 +173,12 @@ See the
 .Sx CONVERSATION SELECTORS
 section below for details.
 .Tg db
-.It Ic export-database Oo Fl d Ar signal-directory Oc Ar file
+.It Xo
+.Ic export-database
+.Op Fl B
+.Op Fl d Ar signal-directory
+.Ar file
+.Xc
 .D1 Pq Alias: Ic db
 .Pp
 Decrypt and export the Signal Desktop database to
@@ -165,7 +187,7 @@ The exported database is a regular SQLite database.
 .Tg key
 .It Xo
 .Ic export-key
-.Op Fl D
+.Op Fl BD
 .Op Fl d Ar signal-directory
 .Op Ar file
 .Xc
@@ -184,7 +206,7 @@ is specified, the database key is exported instead of the encryption key.
 .Tg msg
 .It Xo
 .Ic export-messages
-.Op Fl i
+.Op Fl Bi
 .Op Fl c Ar conversation
 .Op Fl d Ar signal-directory
 .Op Fl f Ar format
@@ -247,6 +269,7 @@ section below for details.
 .Tg query
 .It Xo
 .Ic query-database
+.Op Fl B
 .Op Fl d Ar signal-directory
 .Op Fl o Ar outfile
 .Ar sql
@@ -412,6 +435,11 @@ at
 .Pa /mnt :
 .Bd -literal -offset indent
 $ sigtop db -d /mnt/Users/Alice/AppData/Roaming/Signal signal.db
+.Ed
+.Pp
+Export the database from Signal Desktop Beta:
+.Bd -literal -offset indent
+$ sigtop db -B signal-beta.db
 .Ed
 .Sh SEE ALSO
 .Lk https://github.com/tbvdm/sigtop


### PR DESCRIPTION
Fixes #62 by adding a new `-B` flag, which switches to "Signal Beta" for the keychain and default app directory.