### PR TITLE
ci(release): add multiplatform releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - os: macos-15
-            APP_NAME: sigtop
+            APP_SUFFIX:
             GOOS: darwin
             GOARCH: amd64
           - os: macos-15
@@ -46,13 +46,13 @@ jobs:
           go-version: stable
 
       - name: build
-        run: env GOOS=${{ GOOS }} GOARCH=${{ GOARCH }} go build -ldflags='-s -w' -trimpath -o release/sigtop-${{ GOOS }}-${{ GOARCH }}${{ APP_SUFFIX }}
+        run: env GOOS=${{ matrix.GOOS }} GOARCH=${{ matrix.GOARCH }} go build -ldflags='-s -w' -trimpath -o release/sigtop-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.APP_SUFFIX }}
 
       - name: Generate hash
-        run: sha256sum release/sigtop-${{ GOOS }}-${{ GOARCH }}${{ APP_SUFFIX }} > release/sigtop-${{ GOOS }}-${{ GOARCH }}${{ APP_SUFFIX }}.sha256
+        run: sha256sum release/sigtop-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.APP_SUFFIX }} > release/sigtop-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.APP_SUFFIX }}.sha256
 
       - name: release
         uses: ncipollo/release-action@v1
         with:
           artifactErrorsFailBuild: true
-          artifacts: release/sigtop-${{ GOOS }}-${{ GOARCH }}${{ APP_SUFFIX }},release/sigtop-${{ GOOS }}-${{ GOARCH }}${{ APP_SUFFIX }}.sha256
+          artifacts: release/sigtop-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.APP_SUFFIX }},release/sigtop-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.APP_SUFFIX }}.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
       contents: write
 
     strategy:
+      fail-fast: false
+      max-parallel: 4
       matrix:
         include:
           - os: macos-15
@@ -44,6 +46,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
+
+      - name: Linux dependency
+        run: sudo apt-get install -y libsecret-1-dev
+        if: matrix.GOOS == 'linux'
 
       - name: build
         run: env GOOS=${{ matrix.GOOS }} GOARCH=${{ matrix.GOARCH }} go build -ldflags='-s -w' -trimpath -o release/sigtop-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.APP_SUFFIX }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,38 @@ name: release
 
 on:
   push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+  #   tags:
+  #     - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release:
     permissions:
       contents: write
 
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        - os: macos-15
+          APP_NAME: sigtop
+          GOOS: darwin
+          GOARCH: amd64
+        - os: macos-15
+          APP_SUFFIX:
+          GOOS: darwin
+          GOARCH: arm64
+        - os: ubuntu-24.04
+          APP_SUFFIX:
+          GOOS: linux
+          GOARCH: amd64
+        - os: ubuntu-24.04
+          APP_SUFFIX:
+          GOOS: linux
+          GOARCH: arm64
+        - os: windows-latest
+          APP_SUFFIX: .exe
+          GOOS: windows
+          GOARCH: amd64
+
+    runs-on: ${{matrix.os}}
 
     steps:
       - name: checkout
@@ -22,10 +45,13 @@ jobs:
           go-version: stable
 
       - name: build
-        run: go build -ldflags='-s -w' -trimpath
+        run: env GOOS=${{ GOOS }} GOARCH=${{ GOARCH }} go build -ldflags='-s -w' -trimpath -o release/sigtop-${{ GOOS }}-${{ GOARCH }}${{ APP_SUFFIX }}
+
+      - name: Generate hash
+        run: sha256sum release/sigtop-${{ GOOS }}-${{ GOARCH }}${{ APP_SUFFIX }} > release/sigtop-${{ GOOS }}-${{ GOARCH }}${{ APP_SUFFIX }}.sha256
 
       - name: release
         uses: ncipollo/release-action@v1
         with:
           artifactErrorsFailBuild: true
-          artifacts: sigtop.exe
+          artifacts: release/sigtop-${{ GOOS }}-${{ GOARCH }}${{ APP_SUFFIX }},release/sigtop-${{ GOOS }}-${{ GOARCH }}${{ APP_SUFFIX }}.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,26 +12,27 @@ jobs:
 
     strategy:
       matrix:
-        - os: macos-15
-          APP_NAME: sigtop
-          GOOS: darwin
-          GOARCH: amd64
-        - os: macos-15
-          APP_SUFFIX:
-          GOOS: darwin
-          GOARCH: arm64
-        - os: ubuntu-24.04
-          APP_SUFFIX:
-          GOOS: linux
-          GOARCH: amd64
-        - os: ubuntu-24.04
-          APP_SUFFIX:
-          GOOS: linux
-          GOARCH: arm64
-        - os: windows-latest
-          APP_SUFFIX: .exe
-          GOOS: windows
-          GOARCH: amd64
+        include:
+          - os: macos-15
+            APP_NAME: sigtop
+            GOOS: darwin
+            GOARCH: amd64
+          - os: macos-15
+            APP_SUFFIX:
+            GOOS: darwin
+            GOARCH: arm64
+          - os: ubuntu-24.04
+            APP_SUFFIX:
+            GOOS: linux
+            GOARCH: amd64
+          - os: ubuntu-24.04
+            APP_SUFFIX:
+            GOOS: linux
+            GOARCH: arm64
+          - os: windows-latest
+            APP_SUFFIX: .exe
+            GOOS: windows
+            GOARCH: amd64
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
This is a quick attempt to have releases for multiple platforms/architecture and sha256 files.

mostly failing at ncipollo/release-action as no ref tag in my tests (to restore tags when PR is good)
except macos amd64 and linux arm64
```
Run env GOOS=darwin GOARCH=amd64 go build -ldflags='-s -w' -trimpath -o release/sigtop-darwin-amd64
go: downloading github.com/tbvdm/go-cli v0.1.0
go: downloading github.com/tbvdm/go-openbsd v0.5.0
go: downloading golang.org/x/text v0.21.0
go: downloading golang.org/x/sys v0.29.0
go: downloading golang.org/x/crypto v0.32.0
package github.com/tbvdm/sigtop
	imports github.com/tbvdm/sigtop/signal
	imports github.com/tbvdm/sigtop/sqlcipher: build constraints exclude all Go files in /Users/runner/work/sigtop/sigtop/sqlcipher
Error: Process completed with exit code 1.
```