### PR TITLE
Update Go version matrix in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-14, macos-15, macos-26, ubuntu-22.04, ubuntu-24.04, windows-latest]
-        go: ['1.23', '1.24', '1.25']
+        go: ['1.25', '1.26']
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
Update the Go version matrix in test.yml to test with Go 1.25 and 1.26, dropping older versions (1.23, 1.24) that are no longer relevant given the go.mod minimum of 1.25.0.